### PR TITLE
Add detail to SOCKS setup information on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The module provides a simple command-line utility called `dispatch`.
 ```
 $ dispatch start
 ```
-Start a SOCKS proxy server on `localhost:1080`. Simply add this address as a SOCKS proxy in your system settings and your traffic will be automatically balanced between all available internet connections.
+Start a SOCKS proxy server on `localhost:1080`. Simply add this address as a SOCKS proxy in your system settings for each of the network interfaces and your traffic will be automatically balanced between all available internet connections.
 
 Usage
 -----


### PR DESCRIPTION
Hello @Morhaus . 
This is a simple addition to Readme specifying that, when using SOCKS, all network interfaces must be set up to use the proxy.

I'm wondering if:
1- that is correct or not
and 2- if you would like to add this on the Readme.